### PR TITLE
fix: npm install folder reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,13 @@ FROM goreleaser/goreleaser-cross:${VERSION}
 RUN apt update && \
     apt upgrade -y
 
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
 
 RUN apt-get install nodejs
 
 RUN node -v
 RUN npm -v
 
-RUN chown -R 1000:1000 "/root/.npm"
-RUN npm install -g dart-sass
+RUN chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}
 
-RUN adduser goreleaser --disabled-password
-
-USER goreleaser
+RUN npm install -g sass


### PR DESCRIPTION
# Description

In the past, we encountered an error that said that the binary that was supposed to be installed could not be installed. To fix this issue, we needed to set the correct permissions on the folders to be able to run npm install commands.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] VERSION=dev make build
- [x] docker build -t sample:latest --build-arg VERSION=dev -f Dockerfile .
```Dockerfile
ARG VERSION
FROM docker.fylr.io/goreleaser/goreleaser-cross:${VERSION}

RUN sass --version
```

**Test Configuration**:

- Version: `dev`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works