### PR TITLE
make container image for go 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-VERSION?=v1.19.0
-ORIGIN_VERSION=v1.19.0
+VERSION?=v1.20.0
+ORIGIN_VERSION=v1.20.0
 DOCKER_REGISTRY_URL=docker.fylr.io/goreleaser/goreleaser-cross
 
 build:


### PR DESCRIPTION
# Description

fylr now uses go 1.20

So we need a goreleaser-crosscompile for go 1.20

For #(67725)