### PR TITLE
build for go version 1.21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-VERSION?=v1.20.0
-ORIGIN_VERSION=v1.20.0
+VERSION?=v1.21.1
+ORIGIN_VERSION=v1.21.1
 DOCKER_REGISTRY_URL=docker.fylr.io/goreleaser/goreleaser-cross
 
 build:


### PR DESCRIPTION
We now use go 1.21

For ticket #69929